### PR TITLE
perf: optimize binary size and fix GUI bundle generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,10 @@ jobs:
         working-directory: ui
         run: npx tauri build
 
+      - name: List bundle output
+        shell: bash
+        run: find . -path "*/bundle/*" -type f | sort
+
       - name: Collect artifacts (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -112,6 +116,7 @@ jobs:
         run: |
           mkdir -p gui-artifacts
           find . -name "*.msi" -path "*/bundle/*" -exec cp {} gui-artifacts/kooix-cut-${{ matrix.suffix }}.msi \;
+          find . -name "*.exe" -path "*/bundle/nsis/*" -exec cp {} gui-artifacts/kooix-cut-${{ matrix.suffix }}-setup.exe \;
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ resolver = "2"
 
 [profile.release]
 strip = true
+lto = true
+codegen-units = 1
+opt-level = "z"
+panic = "abort"

--- a/crates/kooix-cli/Cargo.toml
+++ b/crates/kooix-cli/Cargo.toml
@@ -9,6 +9,4 @@ path = "src/main.rs"
 
 [dependencies]
 kooix-core = { path = "../kooix-core" }
-clap = { version = "4", features = ["derive"] }
-indicatif = "0.17"
 anyhow = "1"

--- a/crates/kooix-cli/src/main.rs
+++ b/crates/kooix-cli/src/main.rs
@@ -1,61 +1,70 @@
-use anyhow::Result;
-use clap::Parser;
-use indicatif::{ProgressBar, ProgressStyle};
+use anyhow::{bail, Result};
 use kooix_core::config::Config;
 use kooix_core::video;
+use std::env;
 
-#[derive(Parser)]
-#[command(name = "kooix-cut", version, about = "视频剪辑预处理工具 - 自动合并和删除静音片段")]
-struct Cli {
-    /// 输入目录（包含 mp4 文件）
-    input_dir: String,
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-    /// 输出文件路径
-    #[arg(short, long, default_value = "output.mp4")]
-    output: String,
+fn print_help() {
+    eprintln!(
+        "kooix-cut {VERSION} - 视频剪辑预处理工具 - 自动合并和删除静音片段
 
-    /// 静音阈值 (0.001-1.0)
-    #[arg(short = 't', long, default_value_t = 0.01)]
-    threshold: f64,
+用法: kooix-cut <输入目录> [选项]
 
-    /// 最小有效片段时长（秒）
-    #[arg(short = 'd', long, default_value_t = 3.0)]
-    min_duration: f64,
+选项:
+  -o, --output <文件>       输出文件路径 (默认: output.mp4)
+  -t, --threshold <值>      静音阈值 0.001-1.0 (默认: 0.01)
+  -d, --min-duration <秒>   最小有效片段时长 (默认: 3.0)
+  -c, --codec <编码器>      视频编码器 (默认: libx264)
+  -p, --preset <预设>       编码预设 (默认: fast)
+  -h, --help                显示帮助
+  -V, --version             显示版本"
+    );
+}
 
-    /// 视频编码器
-    #[arg(short, long, default_value = "libx264")]
-    codec: String,
-
-    /// 编码预设
-    #[arg(short, long, default_value = "fast")]
-    preset: String,
+fn parse_next(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+    args.next()
+        .ok_or_else(|| anyhow::anyhow!("{flag} 需要一个参数"))
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let mut args = env::args().skip(1);
+    let mut input_dir = None;
+    let mut output = "output.mp4".to_string();
+    let mut threshold = 0.01f64;
+    let mut min_duration = 3.0f64;
+    let mut codec = "libx264".to_string();
+    let mut preset = "fast".to_string();
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => { print_help(); return Ok(()); }
+            "-V" | "--version" => { eprintln!("kooix-cut {VERSION}"); return Ok(()); }
+            "-o" | "--output" => output = parse_next(&mut args, "-o")?,
+            "-t" | "--threshold" => threshold = parse_next(&mut args, "-t")?.parse()?,
+            "-d" | "--min-duration" => min_duration = parse_next(&mut args, "-d")?.parse()?,
+            "-c" | "--codec" => codec = parse_next(&mut args, "-c")?,
+            "-p" | "--preset" => preset = parse_next(&mut args, "-p")?,
+            s if s.starts_with('-') => bail!("未知选项: {s}\n使用 --help 查看帮助"),
+            _ => input_dir = Some(arg),
+        }
+    }
+
+    let input_dir = input_dir.ok_or_else(|| anyhow::anyhow!("缺少输入目录\n使用 --help 查看帮助"))?;
 
     let config = Config {
-        silence_threshold: cli.threshold,
-        min_duration: cli.min_duration,
-        codec: cli.codec,
-        preset: cli.preset,
-        output_file: cli.output,
+        silence_threshold: threshold,
+        min_duration,
+        codec,
+        preset,
+        output_file: output,
         ..Default::default()
     };
 
-    let pb = ProgressBar::new(0);
-    pb.set_style(
-        ProgressStyle::default_bar()
-            .template("{msg} [{bar:40}] {pos}/{len}")?
-            .progress_chars("█▓░"),
-    );
-
-    video::process_videos(&cli.input_dir, &config, |current, total, name| {
-        pb.set_length(total as u64);
-        pb.set_position(current as u64);
-        pb.set_message(format!("处理: {name}"));
+    video::process_videos(&input_dir, &config, |current, total, name| {
+        eprint!("\r\x1b[K[{current}/{total}] 处理: {name}");
     })?;
 
-    pb.finish_with_message("完成!");
+    eprintln!("\r\x1b[K完成!");
     Ok(())
 }

--- a/ui/src-tauri/Cargo.toml
+++ b/ui/src-tauri/Cargo.toml
@@ -16,5 +16,4 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread"] }

--- a/ui/src-tauri/tauri.conf.json
+++ b/ui/src-tauri/tauri.conf.json
@@ -24,6 +24,17 @@
       "csp": null
     }
   },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ]
+  },
   "plugins": {
     "dialog": {},
     "shell": { "open": true }


### PR DESCRIPTION
## Changes

### Binary Size Optimization
- **Release profile**: Add `lto=true`, `codegen-units=1`, `opt-level="z"`, `panic="abort"`
- **Remove clap + indicatif**: Replace with zero-dependency arg parsing (~280KB savings)
- **Trim GUI deps**: Remove unused `serde_json`, tokio `full` → `rt, rt-multi-thread`

### Fix GUI Installer Generation
- Add `bundle` config to `tauri.conf.json` — this was the root cause of missing .dmg/.deb/.msi in releases
- Add NSIS installer (`.exe`) collection for Windows in CI
- Add debug step to list bundle output for easier troubleshooting

### Expected Impact
| Binary | Before | After (est.) |
|--------|--------|-------------|
| CLI Linux | 1.15 MB | ~500-600 KB |
| CLI macOS | 1.02 MB | ~450-550 KB |
| CLI Windows | 1.02 MB | ~450-550 KB |
| GUI installers | Missing | Now generated |

### Files Changed (6)
- `Cargo.toml` — release profile
- `crates/kooix-cli/Cargo.toml` — remove clap, indicatif
- `crates/kooix-cli/src/main.rs` — rewrite with std arg parsing
- `ui/src-tauri/Cargo.toml` — trim deps
- `ui/src-tauri/tauri.conf.json` — add bundle config
- `.github/workflows/release.yml` — fix artifact collection